### PR TITLE
exp_diss_pearson and exp_diss_spearman in metrics_list. Bump version

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -38,7 +38,9 @@ The following metrics only work if `benchmark_cols` are defined in `full_evaluat
 
 - "corr_with" -> Correlation with benchmark predictions.
 
-- "ex_diss" -> [Exposure Dissimilarity](https://forum.numer.ai/t/true-contribution-details/5128/4) to benchmark predictions.
+- "ex_diss_pearson" (alias "ex_diss") -> [Exposure Dissimilarity](https://forum.numer.ai/t/true-contribution-details/5128/4) to benchmark predictions using Pearson correlation.
+
+- "ex_diss_spearman" -> [Exposure Dissimilarity](https://forum.numer.ai/t/true-contribution-details/5128/4) to benchmark predictions using Spearman correlation. Will be slower compared to "ex_diss_pearson".
 
 ## Numerai Classic specific metrics
 

--- a/numerblox/evaluation.py
+++ b/numerblox/evaluation.py
@@ -1,5 +1,5 @@
+import sys 
 import time
-import inspect
 import numpy as np
 import pandas as pd
 from scipy import stats
@@ -33,7 +33,7 @@ class BaseEvaluator:
     Numerai Classic and Numerai Signals.
 
     Metrics include:
-    - Mean, Standard Deviation and Sharpe for era returns.
+    - Mean, Standard Deviation and Sharpe (Corrv2) for era returns.
     - Max drawdown.
     - Annual Percentage Yield (APY).
     - Correlation with benchmark predictions.
@@ -50,12 +50,8 @@ class BaseEvaluator:
     :param metrics_list: List of metrics to calculate. Default: FAST_METRICS.
     :param era_col: Column name pointing to eras. Most commonly "era" for Numerai Classic and "friday_date" for Numerai Signals.
     :param custom_functions: Additional functions called in evaluation.
-    Each custom function should:
-    - Be a callable (function or class that implements __call__).
-    - Have the following input arguments:
-        - dataf: DataFrame input of evaluation (pd.DataFrame).
-        - pred_col: Column containing the predictions to evaluate (str).
-        - target_col: Column with main target to evaluate against (str).
+    Check out the NumerBlox docs on evaluation for more info on using custom functions.
+    :param show_detailed_progress_bar: Show detailed progress bar for evaluation of each prediction column.
 
     Note that we calculate the sample standard deviation with ddof=0.
     It may differ slightly from the standard Pandas calculation, but
@@ -67,14 +63,16 @@ class BaseEvaluator:
     def __init__(
         self,
         metrics_list: List[str],
-        era_col: str = "era",
-        custom_functions: Dict[str, Dict[str, Any]] = None,
+        era_col: str,
+        custom_functions: Dict[str, Dict[str, Any]],
+        show_detailed_progress_bar: bool,
     ):
         self.era_col = era_col
         self.metrics_list = metrics_list
         self.custom_functions = custom_functions
         if self.custom_functions is not None:
             self.check_custom_functions()
+        self.show_detailed_progress_bar = show_detailed_progress_bar
 
     def full_evaluation(
         self,
@@ -144,6 +142,13 @@ class BaseEvaluator:
         Perform evaluation for one prediction column
         against given target and other prediction column(s).
         """
+        if self.show_detailed_progress_bar:
+            len_metrics_list = len(self.metrics_list)
+            len_benchmark_cols = 0 if benchmark_cols is None else len(benchmark_cols)
+            len_custom_functions = 0 if self.custom_functions is None else len(list(self.custom_functions.keys()))
+            len_pbar = len_metrics_list + len_benchmark_cols + len_custom_functions
+            pbar = tqdm(total=len_pbar, desc="Evaluation")
+
         col_stats = {}
         col_stats["target"] = target_col
 
@@ -154,12 +159,18 @@ class BaseEvaluator:
 
         # check if mean, std, or sharpe are in metrics_list
         if "mean_std_sharpe" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"mean_std_sharpe for evaluation")
+                pbar.update(1)
             mean, std, sharpe = self.mean_std_sharpe(era_corrs=per_era_numerai_corrs)
             col_stats["mean"] = mean
             col_stats["std"] = std
             col_stats["sharpe"] = sharpe
 
         if "legacy_mean_std_sharpe" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"legacy_mean_std_sharpe for evaluation")
+                pbar.update(1)
             per_era_corrs = self.per_era_corrs(
                 dataf=dataf, pred_col=pred_col, target_col=target_col
             )
@@ -171,14 +182,23 @@ class BaseEvaluator:
             col_stats["legacy_sharpe"] = legacy_sharpe
 
         if "max_drawdown" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"max_drawdown for evaluation")
+                pbar.update(1)
             col_stats["max_drawdown"] = self.max_drawdown(
                 era_corrs=per_era_numerai_corrs
             )
 
         if "apy":
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"apy for evaluation")
+                pbar.update(1)
             col_stats["apy"] = self.apy(era_corrs=per_era_numerai_corrs)
 
         if "calmar_ratio" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"calmar_ratio for evaluation")
+                pbar.update(1)
             if not "max_drawdown" in self.metrics_list:
                 col_stats["max_drawdown"] = self.max_drawdown(
                     era_corrs=per_era_numerai_corrs
@@ -192,25 +212,39 @@ class BaseEvaluator:
             )
 
         if "autocorrelation" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description(f"autocorrelation for evaluation")
+                pbar.update(1)
             col_stats["autocorrelation"] = self.autocorr1(per_era_numerai_corrs)
 
         if "max_feature_exposure" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"max_feature_exposure for evaluation")
+                pbar.update(1)
             col_stats["max_feature_exposure"] = self.max_feature_exposure(
                 dataf=dataf, feature_cols=feature_cols, pred_col=pred_col
             )
 
         if "smart_sharpe" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"smart_sharpe for evaluation")
+                pbar.update(1)
             col_stats["smart_sharpe"] = self.smart_sharpe(
                 era_corrs=per_era_numerai_corrs
             )
 
         if benchmark_cols is not None:
             for bench_col in benchmark_cols:
+                if self.show_detailed_progress_bar:
+                    pbar.set_description_str(f"Evaluation for benchmark column: '{bench_col}'")
+                    pbar.update(1)
+
                 per_era_bench_corrs = self.per_era_numerai_corrs(
                     dataf=dataf, pred_col=bench_col, target_col=target_col
                 )
 
                 if "mean_std_sharpe" in self.metrics_list:
+                    pbar.set_description_str(f"mean_std_sharpe for benchmark column: '{bench_col}'")
                     bench_mean, bench_std, bench_sharpe = self.mean_std_sharpe(
                         era_corrs=per_era_bench_corrs
                     )
@@ -219,6 +253,7 @@ class BaseEvaluator:
                     col_stats[f"sharpe_vs_{bench_col}"] = sharpe - bench_sharpe
 
                 if "mc_mean_std_sharpe" in self.metrics_list:
+                    pbar.set_description_str(f"mc_mean_std_sharpe for benchmark column: '{bench_col}'")
                     mc_scores = self.contributive_correlation(
                         dataf=dataf,
                         pred_col=pred_col,
@@ -235,11 +270,13 @@ class BaseEvaluator:
                     )
 
                 if "corr_with" in self.metrics_list:
+                    pbar.set_description_str(f"corr_with for benchmark column: '{bench_col}'")
                     col_stats[f"corr_with_{bench_col}"] = self.cross_correlation(
                         dataf=dataf, pred_col=bench_col, other_col=bench_col
                     )
 
                 if "legacy_mc_mean_std_sharpe" in self.metrics_list:
+                    pbar.set_description_str(f"legacy_mc_mean_std_sharpe for benchmark column: '{bench_col}'")
                     legacy_mc_scores = self.legacy_contribution(
                         dataf=dataf,
                         pred_col=pred_col,
@@ -260,6 +297,7 @@ class BaseEvaluator:
                     )
 
                 if "ex_diss" or "ex_diss_pearson" in self.metrics_list:
+                    pbar.set_description_str(f"ex_diss_pearson for benchmark column: '{bench_col}'")
                     col_stats[
                         f"exposure_dissimilarity_pearson_{bench_col}"
                     ] = self.exposure_dissimilarity(
@@ -267,6 +305,7 @@ class BaseEvaluator:
                         corr_method="pearson"
                     )
                 if "ex_diss_spearman" in self.metrics_list:
+                    pbar.set_description_str(f"ex_diss_spearman for benchmark column: '{bench_col}'")
                     col_stats[
                         f"exposure_dissimilarity_spearman_{bench_col}"
                     ] = self.exposure_dissimilarity(
@@ -276,6 +315,9 @@ class BaseEvaluator:
 
         # Compute intensive stats
         if "fn_mean_std_sharpe" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"fn_mean_std_sharpe for evaluation")
+                pbar.update(1)
             fn_mean, fn_std, fn_sharpe = self.feature_neutral_mean_std_sharpe(
                 dataf=dataf,
                 pred_col=pred_col,
@@ -287,6 +329,9 @@ class BaseEvaluator:
             col_stats["feature_neutral_sharpe"] = fn_sharpe
 
         if "tb200_mean_std_sharpe" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"tb200_mean_std_sharpe for evaluation")
+                pbar.update(1)
             tb200_mean, tb200_std, tb200_sharpe = self.tbx_mean_std_sharpe(
                 dataf=dataf, pred_col=pred_col, target_col=target_col, tb=200
             )
@@ -295,6 +340,9 @@ class BaseEvaluator:
             col_stats["tb200_sharpe"] = tb200_sharpe
 
         if "tb500_mean_std_sharpe" in self.metrics_list:
+            if self.show_detailed_progress_bar:
+                pbar.set_description_str(f"tb500_mean_std_sharpe for evaluation")
+                pbar.update(1)
             tb500_mean, tb500_std, tb500_sharpe = self.tbx_mean_std_sharpe(
                 dataf=dataf, pred_col=pred_col, target_col=target_col, tb=500
             )
@@ -306,6 +354,9 @@ class BaseEvaluator:
         if self.custom_functions is not None:
             local_vars = locals()
             for func_name, func_info in self.custom_functions.items():
+                if self.show_detailed_progress_bar:
+                    pbar.set_description_str(f"custom function: '{func_name}' for evaluation")
+                    pbar.update(1)
                 func = func_info['func']
                 args = func_info['args']
                 local_args = func_info['local_args']
@@ -322,6 +373,8 @@ class BaseEvaluator:
                 col_stats[func_name] = func(**resolved_args)
 
         col_stats_df = pd.DataFrame(col_stats, index=[pred_col])
+        if self.show_detailed_progress_bar:
+            pbar.close()
         return col_stats_df
 
     def per_era_corrs(
@@ -873,15 +926,17 @@ class NumeraiClassicEvaluator(BaseEvaluator):
     def __init__(
         self,
         era_col: str = "era",
-        metrics_list=FAST_METRICS,
-        custom_functions: List[Callable] = None,
+        metrics_list: List[str] = FAST_METRICS,
+        custom_functions: Dict[str, Dict[str, Any]] = None,
+        show_detailed_progress_bar: bool = True,
     ):
         for metric in metrics_list:
             assert (
                 metric in ALL_CLASSIC_METRICS
             ), f"Metric '{metric}' not found. Valid metrics: {ALL_CLASSIC_METRICS}."
         super().__init__(
-            era_col=era_col, metrics_list=metrics_list, custom_functions=custom_functions
+            era_col=era_col, metrics_list=metrics_list, custom_functions=custom_functions,
+            show_detailed_progress_bar=show_detailed_progress_bar
         )
         self.fncv3_features = FNCV3_FEATURES
 
@@ -909,7 +964,8 @@ class NumeraiClassicEvaluator(BaseEvaluator):
             )
             valid_features = []
 
-        for col in tqdm(pred_cols, desc="Evaluation: "):
+        pbar = tqdm(pred_cols, desc="Evaluation ")
+        for col in pbar:
             # Metrics that can be calculated for both Numerai Classic and Signals
             col_stats = self.evaluation_one_col(
                 dataf=dataf,
@@ -920,6 +976,7 @@ class NumeraiClassicEvaluator(BaseEvaluator):
             )
             # Numerai Classic specific metrics
             if valid_features and "fncv3_mean_std_sharpe" in self.metrics_list:
+                pbar.set_description_str(f"fncv3_mean_std_sharpe for evaluation")
                 # Using only valid features defined in FNCV3_FEATURES
                 fnc_v3, fn_std_v3, fn_sharpe_v3 = self.feature_neutral_mean_std_sharpe(
                     dataf=dataf,
@@ -932,6 +989,7 @@ class NumeraiClassicEvaluator(BaseEvaluator):
                 col_stats.loc[col, "feature_neutral_sharpe_v3"] = fn_sharpe_v3
 
             val_stats = pd.concat([val_stats, col_stats], axis=0)
+            pbar.close()
         return val_stats
 
 
@@ -941,15 +999,17 @@ class NumeraiSignalsEvaluator(BaseEvaluator):
     def __init__(
         self,
         era_col: str = "friday_date",
-        metrics_list=FAST_METRICS,
-        custom_functions: List[Callable] = None,
+        metrics_list: List[str] = FAST_METRICS,
+        custom_functions: Dict[str, Dict[str, Any]] = None,
+        show_detailed_progress_bar: bool = True,
     ):
         for metric in metrics_list:
             assert (
                 metric in ALL_SIGNALS_METRICS
             ), f"Metric '{metric}' not found. Valid metrics: {ALL_SIGNALS_METRICS}."
         super().__init__(
-            era_col=era_col, metrics_list=metrics_list, custom_functions=custom_functions
+            era_col=era_col, metrics_list=metrics_list, custom_functions=custom_functions,
+            show_detailed_progress_bar=show_detailed_progress_bar
         )
 
     def get_neutralized_corr(
@@ -962,7 +1022,7 @@ class NumeraiSignalsEvaluator(BaseEvaluator):
         data_type column should contain 'validation' instances. \n
         :param model_name: Any model name for which you have authentication credentials. \n
         :param key: Key object to authenticate upload of diagnostics. \n
-        :param timeout_min: How many minutes to wait on diagnostics processing on Numerai servers before timing out. \n
+        :param timeout_min: How many minutes to wait on diagnostics Computing on Numerai servers before timing out. \n
         2 minutes by default. \n
         :return: Pandas Series with era as index and neutralized validation correlations (validationCorr).
         """

--- a/numerblox/evaluation.py
+++ b/numerblox/evaluation.py
@@ -964,32 +964,31 @@ class NumeraiClassicEvaluator(BaseEvaluator):
             )
             valid_features = []
 
-        pbar = tqdm(pred_cols, desc="Evaluation ")
-        for col in pbar:
-            # Metrics that can be calculated for both Numerai Classic and Signals
-            col_stats = self.evaluation_one_col(
-                dataf=dataf,
-                feature_cols=feature_cols,
-                pred_col=col,
-                target_col=target_col,
-                benchmark_cols=benchmark_cols,
-            )
-            # Numerai Classic specific metrics
-            if valid_features and "fncv3_mean_std_sharpe" in self.metrics_list:
-                pbar.set_description_str(f"fncv3_mean_std_sharpe for evaluation")
-                # Using only valid features defined in FNCV3_FEATURES
-                fnc_v3, fn_std_v3, fn_sharpe_v3 = self.feature_neutral_mean_std_sharpe(
+        with tqdm(pred_cols, desc="Evaluation") as pbar:
+            for col in pbar:
+                # Metrics that can be calculated for both Numerai Classic and Signals
+                col_stats = self.evaluation_one_col(
                     dataf=dataf,
+                    feature_cols=feature_cols,
                     pred_col=col,
                     target_col=target_col,
-                    feature_names=valid_features,
+                    benchmark_cols=benchmark_cols,
                 )
-                col_stats.loc[col, "feature_neutral_mean_v3"] = fnc_v3
-                col_stats.loc[col, "feature_neutral_std_v3"] = fn_std_v3
-                col_stats.loc[col, "feature_neutral_sharpe_v3"] = fn_sharpe_v3
+                # Numerai Classic specific metrics
+                if valid_features and "fncv3_mean_std_sharpe" in self.metrics_list:
+                    pbar.set_description_str(f"fncv3_mean_std_sharpe for evaluation of '{col}'")
+                    # Using only valid features defined in FNCV3_FEATURES
+                    fnc_v3, fn_std_v3, fn_sharpe_v3 = self.feature_neutral_mean_std_sharpe(
+                        dataf=dataf,
+                        pred_col=col,
+                        target_col=target_col,
+                        feature_names=valid_features,
+                    )
+                    col_stats.loc[col, "feature_neutral_mean_v3"] = fnc_v3
+                    col_stats.loc[col, "feature_neutral_std_v3"] = fn_std_v3
+                    col_stats.loc[col, "feature_neutral_sharpe_v3"] = fn_sharpe_v3
 
-            val_stats = pd.concat([val_stats, col_stats], axis=0)
-            pbar.close()
+                val_stats = pd.concat([val_stats, col_stats], axis=0)
         return val_stats
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numerblox"
-version = "1.1.1"
+version = "1.1.2"
 description = "Solid Numerai Pipelines"
 authors = ["CrowdCent <support@crowdcent.com>"]
 license = "MIT License"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -20,7 +20,7 @@ def test_numerai_classic_evaluator_fast_metrics(classic_test_data):
     df.loc[:, "prediction"] = np.random.uniform(size=len(df))
     df.loc[:, "prediction_random"] = np.random.uniform(size=len(df))
 
-    evaluator = NumeraiClassicEvaluator(era_col="era")
+    evaluator = NumeraiClassicEvaluator(era_col="era", show_detailed_progress_bar=False)
     val_stats = evaluator.full_evaluation(
         dataf=df,
         target_col="target",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -53,7 +53,8 @@ def test_numerai_classic_evaluator_all_metrics(classic_test_data):
                                 f"mc_mean_{col}", f"mc_std_{col}", f"mc_sharpe_{col}",
                                 f"corr_with_{col}", 
                                 f"legacy_mc_mean_{col}", f"legacy_mc_std_{col}", f"legacy_mc_sharpe_{col}",
-                                f"exposure_dissimilarity_{col}"
+                                f"exposure_dissimilarity_pearson_{col}",
+                                f"exposure_dissimilarity_spearman_{col}",
                                 ])
     for col in MAIN_CLASSIC_STATS_COLS + BENCHMARK_STATS:
         assert col in val_stats.columns


### PR DESCRIPTION
- Option to set `"ex_diss_peason"` (alias `"ex_diss"`) or `"ex_diss_spearman"` in `metrics_list` for evaluators.
- Detailed progress bar for evaluators.