### PR TITLE
Fix bug where evaluation fails without progress bar.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - master
-  pull_request:
-    branches:
-    - master
 
 jobs:
   build:

--- a/numerblox/evaluation.py
+++ b/numerblox/evaluation.py
@@ -244,7 +244,8 @@ class BaseEvaluator:
                 )
 
                 if "mean_std_sharpe" in self.metrics_list:
-                    pbar.set_description_str(f"mean_std_sharpe for benchmark column: '{bench_col}'")
+                    if self.show_detailed_progress_bar:
+                        pbar.set_description_str(f"mean_std_sharpe for benchmark column: '{bench_col}'")
                     bench_mean, bench_std, bench_sharpe = self.mean_std_sharpe(
                         era_corrs=per_era_bench_corrs
                     )
@@ -253,7 +254,8 @@ class BaseEvaluator:
                     col_stats[f"sharpe_vs_{bench_col}"] = sharpe - bench_sharpe
 
                 if "mc_mean_std_sharpe" in self.metrics_list:
-                    pbar.set_description_str(f"mc_mean_std_sharpe for benchmark column: '{bench_col}'")
+                    if self.show_detailed_progress_bar:
+                        pbar.set_description_str(f"mc_mean_std_sharpe for benchmark column: '{bench_col}'")
                     mc_scores = self.contributive_correlation(
                         dataf=dataf,
                         pred_col=pred_col,
@@ -270,13 +272,15 @@ class BaseEvaluator:
                     )
 
                 if "corr_with" in self.metrics_list:
-                    pbar.set_description_str(f"corr_with for benchmark column: '{bench_col}'")
+                    if self.show_detailed_progress_bar:
+                        pbar.set_description_str(f"corr_with for benchmark column: '{bench_col}'")
                     col_stats[f"corr_with_{bench_col}"] = self.cross_correlation(
                         dataf=dataf, pred_col=bench_col, other_col=bench_col
                     )
 
                 if "legacy_mc_mean_std_sharpe" in self.metrics_list:
-                    pbar.set_description_str(f"legacy_mc_mean_std_sharpe for benchmark column: '{bench_col}'")
+                    if self.show_detailed_progress_bar:
+                        pbar.set_description_str(f"legacy_mc_mean_std_sharpe for benchmark column: '{bench_col}'")
                     legacy_mc_scores = self.legacy_contribution(
                         dataf=dataf,
                         pred_col=pred_col,
@@ -297,7 +301,8 @@ class BaseEvaluator:
                     )
 
                 if "ex_diss" in self.metrics_list or "ex_diss_pearson" in self.metrics_list:
-                    pbar.set_description_str(f"ex_diss_pearson for benchmark column: '{bench_col}'")
+                    if self.show_detailed_progress_bar:
+                        pbar.set_description_str(f"ex_diss_pearson for benchmark column: '{bench_col}'")
                     col_stats[
                         f"exposure_dissimilarity_pearson_{bench_col}"
                     ] = self.exposure_dissimilarity(
@@ -305,7 +310,8 @@ class BaseEvaluator:
                         corr_method="pearson"
                     )
                 if "ex_diss_spearman" in self.metrics_list:
-                    pbar.set_description_str(f"ex_diss_spearman for benchmark column: '{bench_col}'")
+                    if self.show_detailed_progress_bar:
+                        pbar.set_description_str(f"ex_diss_spearman for benchmark column: '{bench_col}'")
                     col_stats[
                         f"exposure_dissimilarity_spearman_{bench_col}"
                     ] = self.exposure_dissimilarity(
@@ -374,6 +380,7 @@ class BaseEvaluator:
 
         col_stats_df = pd.DataFrame(col_stats, index=[pred_col])
         if self.show_detailed_progress_bar:
+            pbar.update(1)
             pbar.close()
         return col_stats_df
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numerblox"
-version = "1.1.3"
+version = "1.1.4"
 description = "Solid Numerai Pipelines"
 authors = ["CrowdCent <support@crowdcent.com>"]
 license = "MIT License"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -38,7 +38,8 @@ def test_numerai_classic_evaluator_all_metrics(classic_test_data):
     df.loc[:, "prediction_random2"] = np.random.uniform(size=len(df))
     benchmark_cols = ["prediction_random", "prediction_random2"]
     evaluator = NumeraiClassicEvaluator(era_col="era", 
-                                        metrics_list=ALL_CLASSIC_METRICS)
+                                        metrics_list=ALL_CLASSIC_METRICS,
+                                        show_detailed_progress_bar=True)
     val_stats = evaluator.full_evaluation(
         dataf=df,
         target_col="target",
@@ -64,7 +65,8 @@ def test_numerai_classic_evaluator_all_metrics(classic_test_data):
 def test_numerai_signals_evaluator(create_signals_sample_data):
     df = create_signals_sample_data
     evaluator = NumeraiSignalsEvaluator(era_col="date",
-                                        metrics_list=FAST_METRICS)
+                                        metrics_list=FAST_METRICS, 
+                                        show_detailed_progress_bar=False)
     val_stats = evaluator.full_evaluation(
         dataf=df,
         target_col="target",
@@ -141,7 +143,8 @@ def test_evaluator_custom_functions(classic_test_data):
     }
     evaluator = NumeraiClassicEvaluator(era_col="era", 
                                         metrics_list=["mean_std_sharpe", "tb500_mean_std_sharpe", "tb200_mean_std_sharpe"],
-                                        custom_functions=custom_functions)
+                                        custom_functions=custom_functions,
+                                        show_detailed_progress_bar=True)
     val_stats = evaluator.full_evaluation(
         dataf=df,
         target_col="target",


### PR DESCRIPTION
1. Fix bug where evaluator would break with `benchmark_cols` defined and `show_detailed_progress_bar=False`.
2. Add 1 at the end to wrap up progress bar.