### PR TITLE
Support for different neutralized corr cols

### DIFF
--- a/numerblox/evaluation.py
+++ b/numerblox/evaluation.py
@@ -1029,7 +1029,8 @@ class NumeraiSignalsEvaluator(BaseEvaluator):
         )
 
     def get_neutralized_corr(
-        self, val_dataf: pd.DataFrame, model_name: str, key: Key, timeout_min: int = 2
+        self, val_dataf: pd.DataFrame, model_name: str, key: Key, timeout_min: int = 2,
+        corr_col: str = "validationFncV4"
     ) -> pd.Series:
         """
         Retrieved neutralized validation correlation by era. \n
@@ -1042,6 +1043,8 @@ class NumeraiSignalsEvaluator(BaseEvaluator):
         2 minutes by default. \n
         :return: Pandas Series with era as index and neutralized validation correlations (validationCorr).
         """
+        VALID_CORR_COLS = ["validationCorrV4", "validationFncV4", "validationIcV2", "validationRic"]
+        assert corr_col in VALID_CORR_COLS, f"corr_col should be one of {VALID_CORR_COLS}. Got: '{corr_col}'"
         api = SignalsAPI(public_id=key.pub_id, secret_key=key.secret_key)
         model_id = api.get_models()[model_name]
         diagnostics_id = api.upload_diagnostics(df=val_dataf, model_id=model_id)
@@ -1051,9 +1054,7 @@ class NumeraiSignalsEvaluator(BaseEvaluator):
             diagnostics_id=diagnostics_id,
             timeout_min=timeout_min,
         )
-        dataf = pd.DataFrame(data["perEraDiagnostics"]).set_index("era")[
-            "validationCorr"
-        ]
+        dataf = pd.DataFrame(data["perEraDiagnostics"]).set_index("era")[corr_col]
         dataf.index = pd.to_datetime(dataf.index)
         return dataf
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numerblox"
-version = "1.1.11"
+version = "1.1.12"
 description = "Solid Numerai Pipelines"
 authors = ["CrowdCent <support@crowdcent.com>"]
 license = "MIT License"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -257,7 +257,7 @@ def mock_api():
         mock_instance.upload_diagnostics.return_value = "test_diag_id"
         
         # Mock diagnostics method
-        mock_instance.diagnostics.return_value = [{"status": "done", "perEraDiagnostics": [{"era": "2023-09-01", "validationCorr": 0.6}]}]
+        mock_instance.diagnostics.return_value = [{"status": "done", "perEraDiagnostics": [{"era": "2023-09-01", "validationFncV4": 0.6, "validationCorrV4": 0.6}]}]
         yield mock_instance
 
 
@@ -274,6 +274,13 @@ def test_get_neutralized_corr(create_signals_sample_data, mock_api):
     mock_api.get_models.assert_called_once()
     mock_api.upload_diagnostics.assert_called_once_with(df=df, model_id='test_model_id')
     mock_api.diagnostics.assert_called()
+
+
+def test_get_neutralized_corr_invalid_corr_col(create_signals_sample_data):
+    df = create_signals_sample_data
+    obj = NumeraiSignalsEvaluator(era_col="date")  
+    with pytest.raises(AssertionError):
+        obj.get_neutralized_corr(df, "test_model", Key("Hello", "World"), corr_col="invalid_corr_col")
 
 
 def test_await_diagnostics_timeout(mock_api):


### PR DESCRIPTION
1. Options for `corr_col` in `NumeraiSignalsEvaluator.get_neutralized_corr`.