### PR TITLE
Feature/no era routing

### DIFF
--- a/numerblox/preprocessing/signals.py
+++ b/numerblox/preprocessing/signals.py
@@ -308,7 +308,7 @@ class EraQuantileProcessor(BasePreProcessor):
         return output_df.to_numpy()
     
     def fit_transform(self, X: Union[np.array, pd.DataFrame], era_series: pd.Series):
-        self.fit(X=X, era_series=era_series)
+        self.fit(X=X)
         return self.transform(X=X, era_series=era_series)
 
     def get_feature_names_out(self, input_features=None) -> List[str]:

--- a/numerblox/preprocessing/signals.py
+++ b/numerblox/preprocessing/signals.py
@@ -283,18 +283,21 @@ class EraQuantileProcessor(BasePreProcessor):
 
     def transform(
         self, X: Union[np.array, pd.DataFrame],
-        era_series: pd.Series,
+        era_series: pd.Series = None,
     ) -> np.array:
         """ 
         Quantile all features by era.
         :param X: Array or DataFrame containing features to be quantiled.
-        :param eras: Series containing era information.
+        :param era_series: Series containing era information.
         :return: Quantiled features.
         """
         X = pd.DataFrame(X)
-        assert X.shape[0] == era_series.shape[0], "Input X and eras must have the same number of rows for quantiling."
+        if era_series is None:
+            warnings.warn("WARNING: 'era_series' not provided for EraQuantileProcessor! Quantiling will be treated as if 'X' is 1 era of data. Ensure you are not passing multiple eras to EraQuantileProcessor in this way! Not providing 'era_series' is valid for live inference, where only one era is used for quantiling.")
+        else:
+            assert X.shape[0] == era_series.shape[0], "Input X and era_series must have the same number of rows for quantiling."
         self.features = [col for col in X.columns]
-        X.loc[:, "era"] = era_series
+        X.loc[:, "era"] = era_series if era_series is not None else "X"
         date_groups = X.groupby('era', group_keys=False)
 
         def process_feature(feature):
@@ -381,10 +384,15 @@ class LagPreProcessor(BasePreProcessor):
         # Metadata routing
         self.set_transform_request(ticker_series=True)
 
-    def transform(self, X: Union[np.array, pd.DataFrame], ticker_series: pd.Series) -> np.array:
+    def transform(self, X: Union[np.array, pd.DataFrame], ticker_series: pd.Series = None) -> np.array:
+        if ticker_series is None:
+            warnings.warn("WARNING: 'era_series' not provided for LagPreProcessor! Lags will be treated as if 'X' is 1 era of data. Ensure you are not passing multiple eras to LagPreProcessor in this way! Not providing 'era_series' is valid for live inference, where only one era is used for creating lags.")
+        else:
+            assert X.shape[0] == ticker_series.shape[0], "Input X and ticker_series must have the same number of rows for lag generation."
+
         X = pd.DataFrame(X)
         feature_cols = X.columns.tolist()
-        X["ticker"] = ticker_series
+        X["ticker"] = ticker_series if ticker_series is not None else "XXXXXXXXXXXXXXXXXXXXXX"
         ticker_groups = X.groupby("ticker")
         output_features = []
         for feature in tqdm(feature_cols, desc="Lag feature generation"):
@@ -445,10 +453,10 @@ class DifferencePreProcessor(BasePreProcessor):
                         if self.pct_diff
                         else X[feature] - X[feature]
                     )
-                X[f"{feature}_diff{day}"] = differenced_values
+                X.loc[:, f"{feature}_diff{day}"] = differenced_values
                 output_features.append(f"{feature}_diff{day}")
                 if self.abs_diff:
-                    X[f"{feature}_absdiff{day}"] = np.abs(
+                    X.loc[:, f"{feature}_absdiff{day}"] = np.abs(
                             X[f"{feature}_diff{day}"]
                         )
                     output_features.append(f"{feature}_absdiff{day}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numerblox"
-version = "1.3.0"
+version = "1.3.1"
 description = "Solid Numerai Pipelines"
 authors = ["CrowdCent <support@crowdcent.com>"]
 license = "MIT License"

--- a/tests/test_neutralizers.py
+++ b/tests/test_neutralizers.py
@@ -100,7 +100,6 @@ def test_feature_neutralizer_transform_no_era(setup_data):
     assert np.all(np.isclose(result, 1, atol=1e-8) | (result <= 1))
 
     fn.set_transform_request(era_series=False)
-    result = fn.transform(X, features=features)
     # Ensure warning is raised
     with pytest.warns(UserWarning):
         result2 = fn.transform(X, features=features)

--- a/tests/test_neutralizers.py
+++ b/tests/test_neutralizers.py
@@ -89,24 +89,32 @@ def test_feature_neutralizer_predict(setup_data):
 
 def test_feature_neutralizer_transform_no_era(setup_data):
     fn = FeatureNeutralizer(pred_name="prediction", proportion=0.5)
-    fn.set_transform_request(era_series=False)
     features = setup_data[["feature1", "feature2"]]
     X = setup_data["prediction"]
-    result = fn.transform(X, features=features)
-    # Ensure warning is raised
+    # Ensure warning is raised. Omitting era_series with .set_transform_request(era_series=True) does not raise an error.
     with pytest.warns(UserWarning):
-        result = fn.transform(X, features=features)
+        result = make_pipeline(fn).transform(X, features=features)
     assert len(result) == len(setup_data)
     assert result.shape[1] == 1
     assert np.all(np.isclose(result, 0, atol=1e-8) | (result >= 0))
     assert np.all(np.isclose(result, 1, atol=1e-8) | (result <= 1))
 
+    fn.set_transform_request(era_series=False)
+    result = fn.transform(X, features=features)
+    # Ensure warning is raised
+    with pytest.warns(UserWarning):
+        result2 = fn.transform(X, features=features)
+    assert np.all(result == result2)
+    assert len(result2) == len(setup_data)
+    assert result2.shape[1] == 1
+    assert np.all(np.isclose(result2, 0, atol=1e-8) | (result >= 0))
+    assert np.all(np.isclose(result2, 1, atol=1e-8) | (result <= 1))
+
     fn.set_transform_request(era_series=None)
     era_series = setup_data["era"]
-    pipe = make_pipeline(fn)
     # Passing era_series should give an error with metadata routing set to None
     with pytest.raises(ValueError):
-        result = pipe.fit_transform(X, features=features, era_series=era_series)
+        make_pipeline(fn).fit_transform(X, features=features, era_series=era_series)
 
 def test_feature_neutralizer_predict_multi_pred(setup_data):
     fn = FeatureNeutralizer(pred_name=["prediction", "prediction2"], proportion=[0.5])


### PR DESCRIPTION
1. Option in metadata routing to omit `era_series` or `ticker_series` for some components. In this case the data will be treated as containing one era or ticker respectively. This can be convenient in processing live data or batches. A clear warning will be given in this case.